### PR TITLE
Corrected bug in raster_variate.hpp

### DIFF
--- a/include/rjmcmc/rjmcmc/kernel/raster_variate.hpp
+++ b/include/rjmcmc/rjmcmc/kernel/raster_variate.hpp
@@ -77,7 +77,7 @@ namespace rjmcmc {
             for(int i=0; i<N; ++i)
             {
                 double x = *it++;
-                if(x<0. || x>1.) return 0.;
+                if(x<0. || x>=1.) return 0.;
                 int ix = int(x*m_size[i]);
                 offset += stride*ix;
                 stride *= m_size[i];


### PR DESCRIPTION
in line 80: in the case where x=1. cause offset become bigger than the size of m_cdf. 
I propose to change the condition to x>=0.
